### PR TITLE
chore: disable KICS security scanner

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -19,6 +19,7 @@ BASH_SHFMT_ARGUMENTS: --case-indent --indent 2 --space-redirects
 DISABLE_LINTERS:
   - MARKDOWN_MARKDOWNLINT # Using rumdl instead (faster Rust-based alternative)
   - MARKDOWN_MARKDOWN_LINK_CHECK # Using lychee instead for link checking (more configurable)
+  - REPOSITORY_KICS # KICS security scanner disabled
   - SPELL_CSPELL # Spell checking disabled - prone to false positives
   - TERRAFORM_TERRASCAN # Hard to configure - no clear documentation of the config file format
 
@@ -57,9 +58,6 @@ REPOSITORY_CHECKOV_ARGUMENTS: --quiet
 #   - DS162092: "Do not leave debug code in production"
 #   - DS137138: "Insecure URL" (for HTTP links that are intentional)
 REPOSITORY_DEVSKIM_ARGUMENTS: --ignore-globs CHANGELOG.md --ignore-rule-ids DS162092,DS137138
-
-# KICS (security scanner) - only fail on high severity issues
-REPOSITORY_KICS_ARGUMENTS: --fail-on high
 
 # Trivy (vulnerability scanner) - only check HIGH and CRITICAL severity
 REPOSITORY_TRIVY_ARGUMENTS: --severity HIGH,CRITICAL --ignore-unfixed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ jsonlint --comments file.json
 actionlint
 
 # Security scanning (CI only, via MegaLinter)
-# checkov, DevSkim, KICS (--fail-on high), trivy (HIGH,CRITICAL)
+# checkov, DevSkim, trivy (HIGH,CRITICAL)
 ```
 
 There are **no unit tests or test framework**. Quality is enforced
@@ -99,7 +99,6 @@ CI runs multiple scanners (all configured in `.mega-linter.yml`):
 - **Checkov**: IaC scanner (skips `CKV_GHA_7`)
 - **DevSkim**: Pattern scanner (ignores DS162092, DS137138;
   excludes `CHANGELOG.md`)
-- **KICS**: Fails only on HIGH severity
 - **Trivy**: HIGH/CRITICAL only, ignores unfixed vulnerabilities
 
 ## Version Control


### PR DESCRIPTION
## Summary

- Disable KICS security scanner by adding it to `DISABLE_LINTERS` in `.mega-linter.yml`
- Remove `REPOSITORY_KICS_ARGUMENTS` configuration
- Update `AGENTS.md` to remove KICS references